### PR TITLE
Add config option for quotes

### DIFF
--- a/lib/shortcode/configuration.rb
+++ b/lib/shortcode/configuration.rb
@@ -11,10 +11,14 @@ class Shortcode::Configuration
   # Set the supported self_closing_tags
   attr_accessor :self_closing_tags
 
+  # Set the quotation sign used for attribute values. Defaults to double quote (")
+  attr_accessor :quotes
+
   def initialize
     @template_parser    = :haml
     @template_path      = "app/views/shortcode_templates"
     @block_tags         = []
     @self_closing_tags  = []
+    @quotes             = '"'
   end
 end

--- a/lib/shortcode/parser.rb
+++ b/lib/shortcode/parser.rb
@@ -3,7 +3,7 @@ class Shortcode::Parser < Parslet::Parser
   rule(:block_tag)        { match_any_of Shortcode.configuration.block_tags }
   rule(:self_closing_tag) { match_any_of Shortcode.configuration.self_closing_tags }
 
-  rule(:quotes) { str('"') }
+  rule(:quotes) { str(Shortcode.configuration.quotes) }
 
   rule(:space)        { str(' ').repeat(1) }
   rule(:space?)       { space.maybe }

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -25,6 +25,22 @@ describe Shortcode::Parser do
     end
   end
 
+  it "parses quotes using custom quotations" do
+    Shortcode.setup do |config|
+      config.quotes = "'"
+    end
+
+    quotes.each do |string|
+      # Change double quotes to single quotes in the fixture
+      parser.should parse(string.gsub '"', "'")
+    end
+
+    # Reset configuration to default
+    Shortcode.setup do |config|
+      config.quotes = '"'
+    end
+  end
+
   it "parses list shortcodes" do
     collapsible_lists.each do |string|
       parser.should parse(string)


### PR DESCRIPTION
I've had problems using double quotes in some WYSIWYG editors as they get html encoded and you need to disable the feature which is sometimes hard to do (not well documented). Let used decide which quote sign they want to use.

I didn't find an appropriate place to test this behaviour. Feel free to (re)move it.
