### PR TITLE
Optional quotes around the value.

### DIFF
--- a/lib/shortcode/configuration.rb
+++ b/lib/shortcode/configuration.rb
@@ -20,6 +20,9 @@ class Shortcode::Configuration
   # Set the quotation sign used for attribute values. Defaults to double quote (")
   attr_accessor :quotes
 
+  # Allows quotes to be omitted. Defaults to false (quotes must be present around the value).
+  attr_accessor :optional_quotes
+
   def initialize
     @template_parser    = :erb
     @template_path      = "app/views/shortcode_templates"
@@ -28,5 +31,6 @@ class Shortcode::Configuration
     @block_tags         = []
     @self_closing_tags  = []
     @quotes             = '"'
+    @optional_quotes    = false
   end
 end

--- a/lib/shortcode/parser.rb
+++ b/lib/shortcode/parser.rb
@@ -12,7 +12,10 @@ class Shortcode::Parser < Parslet::Parser
   rule(:whitespace?)  { whitespace.maybe }
 
   rule(:key)    { match('[a-zA-Z0-9\-_]').repeat(1) }
-  rule(:value)  { quotes >> (quotes.absent? >> any).repeat.as(:value) >> quotes }
+
+  rule(:value_with_quotes)  { quotes >> (quotes.absent? >> any).repeat.as(:value) >> quotes }
+  rule(:value_without_quotes) { quotes.absent? >> ( (str(']') | whitespace).absent? >> any ).repeat.as(:value) }
+  rule(:value)    { Shortcode.configuration.optional_quotes ? (value_without_quotes | value_with_quotes) : value_with_quotes }
 
   rule(:option)   { key.as(:key) >> str('=') >> value }
   rule(:options)  { (str(' ') >> option).repeat(1) }

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -8,6 +8,7 @@ describe Shortcode::Parser do
 
   let(:simple_quote)      { load_fixture :simple_quote }
   let(:full_quote)        { load_fixture :full_quote }
+  let(:without_quotes)    { load_fixture :without_quotes }
   let(:quote_with_extras) { load_fixture :quote_with_extras }
   let(:simple_list)       { load_fixture :simple_list }
   let(:timeline_event)    { load_fixture :timeline_event }
@@ -38,6 +39,19 @@ describe Shortcode::Parser do
     # Reset configuration to default
     Shortcode.setup do |config|
       config.quotes = '"'
+    end
+  end
+
+  it "parses shortcodes with optional quotes" do
+    Shortcode.setup do |config|
+      config.optional_quotes = true
+    end
+
+    expect(parser).to parse(without_quotes)
+
+    # Reset configuration to default
+    Shortcode.setup do |config|
+      config.optional_quotes = false
     end
   end
 

--- a/spec/support/fixtures/without_quotes.txt
+++ b/spec/support/fixtures/without_quotes.txt
@@ -1,0 +1,1 @@
+[quote author="Jamie Dyer" title=King_of_England]A quote[/quote]


### PR DESCRIPTION
I'm not sure if you actually want this feature or not, but I'm using this gem in a context where interoperability with the WordPress shortcode engine is pretty important.
