### PR TITLE
Fix issue #30 by storing class names instead of the entire class

### DIFF
--- a/lib/shortcode/presenter.rb
+++ b/lib/shortcode/presenter.rb
@@ -9,7 +9,7 @@ class Shortcode::Presenter
 
     def register(presenter)
       validate presenter
-      [*presenter.for].each { |k| presenters[k.to_sym] = presenter }
+      [*presenter.for].each { |k| presenters[k.to_sym] = presenter.to_s }
     end
 
     def validate(presenter)
@@ -40,7 +40,7 @@ class Shortcode::Presenter
 
     def initialize_custom_presenter(name)
       if Shortcode::Presenter.presenters.has_key? name.to_sym
-        presenter   = Shortcode::Presenter.presenters[name.to_sym].new(@attributes, @content, @additional_attributes)
+        presenter   = Shortcode::Presenter.presenters[name.to_sym].constantize.new(@attributes, @content, @additional_attributes)
         @attributes = presenter.attributes
         @content    = presenter.content
       end


### PR DESCRIPTION
I was right about my hypothesis to fix #30.

Storing the presenter class name instead of the class itself solved the autoloading issue. We can now store our presenters in the app/presenters directory and register them in an initializer. 
