### PR TITLE
Multiple shortcode instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.0.0 (May 21, 2017)
+
+Features:
+
+  - Shortcode converted from module to a class
+  - Separate instances of Shortcode have separate configurations
+  - Updated to parslet 1.8.0
+  - Updated to rspec 3.6
+
+Misc:
+
+  - Testing against the latest versions of Rails 5.0 & 5.1
+
 ## 1.1.1 (September 14, 2015)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,18 @@ Rails versions 4.1, 4.2, 5.0 and 5.1.
 
 Shortcode is very simple to use, simply call the `process` method and pass it a string containing shortcode markup.
 
+You can create multiple instances of `Shortcode` with separate configurations for each, or you can call methods directly on `Shortcode` to use the same configuration throughout.  Throughout this Readme we will refer to calling methods directly on the class as "Singleton", and creating multiple instances as "Instance"
+
+#### Singleton
+
 ```ruby
 Shortcode.process("[quote]Hello World[/quote]")
+```
+
+#### Instance
+```ruby
+shortcode = Shortcode.new
+shortcode.process("[quote]Hello World[/quote]")
 ```
 
 In a Rails app, you can create helper methods to handle your shortcoded content and use them in your views with something similar to `<%= content_html @page.content %>`. Those two helper method can be used if your content contains html to be escaped or not.
@@ -58,10 +68,31 @@ end
 
 Any tags you wish to use with Shortcode need to be configured in the setup block, there are 2 types of tag, `block_tags` and `self_closing_tags`. Block tags have a matching open and close tag such as `[quote]A quote[/quote]`, self closing tags have no close tag, for example `[gallery]`. To define the tags Shortcode should parse do so in the configuration (in a Rails initializer for example) as follows:
 
+#### Singleton
+
 ```ruby
 Shortcode.setup do |config|
   config.block_tags = [:quote, :list]
   config.self_closing_tags = [:gallery, :widget]
+end
+```
+
+#### Instance
+```ruby
+shortcode = Shortcode.new
+shortcode.setup do |config|
+  config.block_tags = [:quote, :list]
+  config.self_closing_tags = [:gallery, :widget]
+end
+```
+
+Note that you can call the setup block multiple times if need be and add to it.
+
+For example:
+
+```ruby
+shortcode.setup do |config|
+  config.block_tags << :other_tag
 end
 ```
 
@@ -117,8 +148,20 @@ Note: only 1 template parser is supported at a time, if using haml for instance 
 The alternative way to define templates is to set them using the `templates` config option, this option can take a hash with keys of the same name as the shortcode tags and
 values containing a template string. For instance:
 
+##### Singleton
+
 ```ruby
 Shortcode.setup do |config|
+  config.templates = { gallery: 'template code' }
+end
+```
+
+##### Instance
+
+```ruby
+shortcode = Shortcode.new
+
+shortcode.setup do |config|
   config.templates = { gallery: 'template code' }
 end
 ```
@@ -132,8 +175,20 @@ Note: it's NOT possible to load templates from a config option AND from the file
 
 If you wish to use custom helper modules in templates you can do so by specifying the helpers in a setup block which should be an array. Methods in the helper modules will then become available within all templates.
 
+#### Singleton
+
 ```ruby
 Shortcode.setup do |config|
+  config.helpers = [CustomHelper, AnotherCustomHelper]
+end
+```
+
+#### Instance
+
+```ruby
+shortcode = Shortcode.new
+
+shortcode.setup do |config|
   config.helpers = [CustomHelper, AnotherCustomHelper]
 end
 ```
@@ -167,15 +222,15 @@ class GalleryPresenter
 
   private
 
-    def images
-      Image.where("id IN (?)", @attributes[:ids])
-    end
+  def images
+    Image.where("id IN (?)", @attributes[:ids])
+  end
 end
 ```
 
 #### Using additional attributes
 
-At times you may want to pass through additional attributes to a presenter, for instance if you have a [gallery] shortcode tag and you want to pull out all images for a post, this can be achived using additional attributes with a presenter.
+At times you may want to pass through additional attributes to a presenter, for instance if you have a [gallery] shortcode tag and you want to pull out all images for a post, this can be achieved using additional attributes with a presenter.
 
 ```ruby
 class GalleryPresenter
@@ -199,20 +254,32 @@ class GalleryPresenter
 
   private
 
-    def images
-      @additional_attributes[:images].map &:url
-    end
+  def images
+    @additional_attributes[:images].map &:url
+  end
 end
+```
 
-# The hash containing the images attribute is passed through to the presenter
-# as the additional_attributes argument
+The hash containing the images attribute is passed through to the presenter as the additional_attributes argument to the `process` method.
+
+##### Singleton
+
+```ruby
 Shortcode.process('[gallery]', { images: @post.images })
+```
 
+##### Instance
+
+```ruby
+shortcode = Shortcode.new
+shortcode.process('[gallery]', { images: @post.images })
 ```
 
 #### Registering presenters
 
-To register a presenter simply call `Shortcode.register_presenter` passing the presenter class e.g.
+To register a presenter simply call `register_presenter` passing the presenter class e.g.
+
+##### Singleton
 
 ```ruby
 # A single presenter
@@ -220,10 +287,25 @@ Shortcode.register_presenter(CustomPresenter)
 
 # Or multiple presenters in one call
 Shortcode.register_presenter(CustomPresenter, AnotherPresenter)
+```
 
+##### Instance
+
+```ruby
+shortcode = Shortcode.new
+
+# A single presenter
+shortcode.register_presenter(CustomPresenter)
+
+# Or multiple presenters in one call
+shortcode.register_presenter(CustomPresenter, AnotherPresenter)
 ```
 
 ### Configuration
+
+The following configuration options can be set for both singleton and instances modes of Shortcode.  You can call `setup` multiple times and modify the existing configuration.
+
+#### Singleton
 
 ```ruby
 Shortcode.setup do |config|
@@ -256,6 +338,40 @@ Shortcode.setup do |config|
 end
 ```
 
+#### Instance
+
+```ruby
+shortcode = Shortcode.new
+
+shortcode.setup do |config|
+
+  # the template parser to use
+  config.template_parser = :erb # :erb, :haml, :slim supported, :erb is default
+
+  # location of the template files, default is "app/views/shortcode_templates"
+  config.template_path = "support/templates/erb"
+
+  # a hash of templates passed as strings, if this is set it overrides the
+  # above template_path option. The default is nil
+  config.templates = { gallery: 'template code' }
+
+  # an array of helper modules to make available within templates
+  config.helpers = [CustomerHelper]
+
+  # a list of block tags to support e.g. [quote]Hello World[/quote]
+  config.block_tags = [:quote]
+
+  # a list of self closing tags to support e.g. [youtube id="12345"]
+  config.self_closing_tags = [:youtube]
+
+  # the type of quotes to use for attribute values, default is double quotes (")
+  config.attribute_quote_type = '"'
+
+  # Allows quotes around attributes to be omitted
+  # Defaults to true, quotes must be present around attribute values
+  config.use_attribute_quotes = true
+end
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -36,15 +36,8 @@ Rails versions 4.1, 4.2, 5.0 and 5.1.
 
 Shortcode is very simple to use, simply call the `process` method and pass it a string containing shortcode markup.
 
-You can create multiple instances of `Shortcode` with separate configurations for each, or you can call methods directly on `Shortcode` to use the same configuration throughout.  Throughout this Readme we will refer to calling methods directly on the class as "Singleton", and creating multiple instances as "Instance"
+You can create multiple instances of `Shortcode` with separate configurations for each.
 
-#### Singleton
-
-```ruby
-Shortcode.process("[quote]Hello World[/quote]")
-```
-
-#### Instance
 ```ruby
 shortcode = Shortcode.new
 shortcode.process("[quote]Hello World[/quote]")
@@ -68,16 +61,6 @@ end
 
 Any tags you wish to use with Shortcode need to be configured in the setup block, there are 2 types of tag, `block_tags` and `self_closing_tags`. Block tags have a matching open and close tag such as `[quote]A quote[/quote]`, self closing tags have no close tag, for example `[gallery]`. To define the tags Shortcode should parse do so in the configuration (in a Rails initializer for example) as follows:
 
-#### Singleton
-
-```ruby
-Shortcode.setup do |config|
-  config.block_tags = [:quote, :list]
-  config.self_closing_tags = [:gallery, :widget]
-end
-```
-
-#### Instance
 ```ruby
 shortcode = Shortcode.new
 shortcode.setup do |config|
@@ -148,16 +131,6 @@ Note: only 1 template parser is supported at a time, if using haml for instance 
 The alternative way to define templates is to set them using the `templates` config option, this option can take a hash with keys of the same name as the shortcode tags and
 values containing a template string. For instance:
 
-##### Singleton
-
-```ruby
-Shortcode.setup do |config|
-  config.templates = { gallery: 'template code' }
-end
-```
-
-##### Instance
-
 ```ruby
 shortcode = Shortcode.new
 
@@ -174,16 +147,6 @@ Note: it's NOT possible to load templates from a config option AND from the file
 ### Custom Helpers
 
 If you wish to use custom helper modules in templates you can do so by specifying the helpers in a setup block which should be an array. Methods in the helper modules will then become available within all templates.
-
-#### Singleton
-
-```ruby
-Shortcode.setup do |config|
-  config.helpers = [CustomHelper, AnotherCustomHelper]
-end
-```
-
-#### Instance
 
 ```ruby
 shortcode = Shortcode.new
@@ -262,14 +225,6 @@ end
 
 The hash containing the images attribute is passed through to the presenter as the additional_attributes argument to the `process` method.
 
-##### Singleton
-
-```ruby
-Shortcode.process('[gallery]', { images: @post.images })
-```
-
-##### Instance
-
 ```ruby
 shortcode = Shortcode.new
 shortcode.process('[gallery]', { images: @post.images })
@@ -278,18 +233,6 @@ shortcode.process('[gallery]', { images: @post.images })
 #### Registering presenters
 
 To register a presenter simply call `register_presenter` passing the presenter class e.g.
-
-##### Singleton
-
-```ruby
-# A single presenter
-Shortcode.register_presenter(CustomPresenter)
-
-# Or multiple presenters in one call
-Shortcode.register_presenter(CustomPresenter, AnotherPresenter)
-```
-
-##### Instance
 
 ```ruby
 shortcode = Shortcode.new
@@ -302,43 +245,6 @@ shortcode.register_presenter(CustomPresenter, AnotherPresenter)
 ```
 
 ### Configuration
-
-The following configuration options can be set for both singleton and instances modes of Shortcode.  You can call `setup` multiple times and modify the existing configuration.
-
-#### Singleton
-
-```ruby
-Shortcode.setup do |config|
-
-  # the template parser to use
-  config.template_parser = :erb # :erb, :haml, :slim supported, :erb is default
-
-  # location of the template files, default is "app/views/shortcode_templates"
-  config.template_path = "support/templates/erb"
-
-  # a hash of templates passed as strings, if this is set it overrides the
-  # above template_path option. The default is nil
-  config.templates = { gallery: 'template code' }
-
-  # an array of helper modules to make available within templates
-  config.helpers = [CustomerHelper]
-
-  # a list of block tags to support e.g. [quote]Hello World[/quote]
-  config.block_tags = [:quote]
-
-  # a list of self closing tags to support e.g. [youtube id="12345"]
-  config.self_closing_tags = [:youtube]
-
-  # the type of quotes to use for attribute values, default is double quotes (")
-  config.attribute_quote_type = '"'
-
-  # Allows quotes around attributes to be omitted
-  # Defaults to true, quotes must be present around attribute values
-  config.use_attribute_quotes = true
-end
-```
-
-#### Instance
 
 ```ruby
 shortcode = Shortcode.new
@@ -371,6 +277,24 @@ shortcode.setup do |config|
   # Defaults to true, quotes must be present around attribute values
   config.use_attribute_quotes = true
 end
+```
+
+### Singleton
+
+You can optionally use Shortcode as a singleton instance with the same configuration throughout.
+
+To do this, you call methods directly on the `Shortcode` class.
+
+For example:
+
+```ruby
+Shortcode.setup do |config|
+  config.block_tags = [:quote]
+end
+
+Shortcode.register_presenter(QuotePresenterClass)
+
+Shortcode.process('[quote]Some quote[/quote]')
 ```
 
 ## Contributing

--- a/lib/shortcode.rb
+++ b/lib/shortcode.rb
@@ -9,32 +9,41 @@ begin
   require 'slim'
 rescue LoadError; end
 
-module Shortcode
-
-  class << self
-    attr_writer :configuration
-  end
-
+class Shortcode
+  # This is providedc for backwards compatibility
   def self.process(string, additional_attributes=nil)
-    Shortcode::Processor.new.process string, additional_attributes
+    singleton.process(string, additional_attributes)
   end
 
-  def self.setup
+  # This is provided for backwards compatibility
+  def self.singleton
+    @instance ||= new
+  end
+
+  # This is providedc for backwards compatibility
+  def self.setup(&prc)
+    singleton.setup(&prc)
+  end
+
+  def process(string, additional_attributes=nil)
+    Shortcode::Processor.new.process(string, configuration, additional_attributes)
+  end
+
+  def setup
     yield configuration
   end
 
-  def self.register_presenter(*presenters)
+  def register_presenter(*presenters)
     presenters.each do |presenter|
-      Shortcode::Presenter.register presenter
+      configuration.register_presenter(presenter)
     end
   end
 
   private
 
-    def self.configuration
-      @configuration ||= Configuration.new
-    end
-
+  def configuration
+    @configuration ||= Configuration.new
+  end
 end
 
 require 'shortcode/version'

--- a/lib/shortcode.rb
+++ b/lib/shortcode.rb
@@ -25,6 +25,11 @@ class Shortcode
     singleton.setup(&prc)
   end
 
+  # This is providedc for backwards compatibility
+  def self.register_presenter(*presenters)
+    singleton.register_presenter(*presenters)
+  end
+
   def process(string, additional_attributes=nil)
     Shortcode::Processor.new.process(string, configuration, additional_attributes)
   end

--- a/lib/shortcode/configuration.rb
+++ b/lib/shortcode/configuration.rb
@@ -11,6 +11,9 @@ class Shortcode::Configuration
   # Assigns helper modules to be included in templates
   attr_accessor :helpers
 
+  # Allows presenters to be set that can be used to process shortcode arguments before rendered
+  attr_accessor :presenters
+
   # Set the supported block_tags
   attr_reader :block_tags
   def block_tags=(block_tags)
@@ -38,5 +41,10 @@ class Shortcode::Configuration
     @self_closing_tags    = []
     @attribute_quote_type = '"'
     @use_attribute_quotes = true
+    @presenters           = {}
+  end
+
+  def register_presenter(presenter)
+    Shortcode::Presenter.register(self, presenter)
   end
 end

--- a/lib/shortcode/exceptions.rb
+++ b/lib/shortcode/exceptions.rb
@@ -1,4 +1,4 @@
-module Shortcode
+class Shortcode
 
   # Raised when the template file can not be found
   class TemplateNotFound < StandardError; end

--- a/lib/shortcode/parser.rb
+++ b/lib/shortcode/parser.rb
@@ -8,6 +8,10 @@ class Shortcode::Parser
     klass_instance.parse(string)
   end
 
+  def open(*args)
+    klass_instance.open(*args)
+  end
+
   private
 
   # This allows us to create a new class with the rules for the specific configuration

--- a/lib/shortcode/parser.rb
+++ b/lib/shortcode/parser.rb
@@ -1,43 +1,69 @@
-class Shortcode::Parser < Parslet::Parser
+class Shortcode::Parser
+  def initialize(configuration)
+    @configuration = configuration
+    setup_rules
+  end
 
-  rule(:block_tag)        { match_any_of Shortcode.configuration.block_tags }
-  rule(:self_closing_tag) { match_any_of Shortcode.configuration.self_closing_tags }
-
-  rule(:quotes) { str(Shortcode.configuration.attribute_quote_type) }
-
-  rule(:space)        { str(' ').repeat(1) }
-  rule(:space?)       { space.maybe }
-  rule(:newline)      { (str("\r\n") | str("\n")) >> space? }
-  rule(:newline?)     { newline.maybe }
-  rule(:whitespace)   { (space | newline).repeat(1) }
-
-  rule(:key) { match('[a-zA-Z0-9\-_]').repeat(1) }
-
-  rule(:value_with_quotes) { quotes >> (quotes.absent? >> any).repeat.as(:value) >> quotes }
-  rule(:value_without_quotes) { quotes.absent? >> ( (str(']') | whitespace).absent? >> any ).repeat.as(:value) }
-  rule(:value) { Shortcode.configuration.use_attribute_quotes ? value_with_quotes : (value_without_quotes | value_with_quotes) }
-
-  rule(:option)   { key.as(:key) >> str('=') >> value }
-  rule(:options)  { (str(' ') >> option).repeat(1) }
-  rule(:options?) { options.repeat(0, 1) }
-
-  rule(:open)       { str('[') >> block_tag.as(:open) >> options?.as(:options) >> str(']') >> newline? }
-  rule(:close)      { str('[/') >> block_tag.as(:close) >> str(']') >> newline? }
-  rule(:open_close) { str('[') >> self_closing_tag.as(:open_close) >> options?.as(:options) >> str(']') >> newline? }
-
-  rule(:text)   { ((close | block | open_close).absent? >> any).repeat(1).as(:text) }
-  rule(:block)  { (open >> (block | text | open_close).repeat.as(:inner) >> close) }
-
-  rule(:body) { (block | text | open_close).repeat.as(:body) }
-  root(:body)
+  def parse(string)
+    klass_instance.parse(string)
+  end
 
   private
 
-    def match_any_of(tags)
-      return str('') if tags.length < 1
-      tags.map{ |tag| str(tag) }.inject do |tag_chain, tag|
-        tag_chain.send :|, tag
+  # This allows us to create a new class with the rules for the specific configuration
+  def klass
+    @klass ||= Class.new(Parslet::Parser)
+  end
+
+  def klass_instance
+    @klass_instance ||= klass.new
+  end
+
+  def setup_rules
+    define_match_any_of
+
+    shortcode_configuration = @configuration
+    klass.rule(:block_tag)        { match_any_of shortcode_configuration.block_tags }
+    klass.rule(:self_closing_tag) { match_any_of shortcode_configuration.self_closing_tags }
+
+    klass.rule(:quotes) { str(shortcode_configuration.attribute_quote_type) }
+
+    klass.rule(:space)        { str(' ').repeat(1) }
+    klass.rule(:space?)       { space.maybe }
+    klass.rule(:newline)      { (str("\r\n") | str("\n")) >> space? }
+    klass.rule(:newline?)     { newline.maybe }
+    klass.rule(:whitespace)   { (space | newline).repeat(1) }
+
+    klass.rule(:key) { match('[a-zA-Z0-9\-_]').repeat(1) }
+
+    klass.rule(:value_with_quotes) { quotes >> (quotes.absent? >> any).repeat.as(:value) >> quotes }
+    klass.rule(:value_without_quotes) { quotes.absent? >> ( (str(']') | whitespace).absent? >> any ).repeat.as(:value) }
+    klass.rule(:value) { shortcode_configuration.use_attribute_quotes ? value_with_quotes : (value_without_quotes | value_with_quotes) }
+
+    klass.rule(:option)   { key.as(:key) >> str('=') >> value }
+    klass.rule(:options)  { (str(' ') >> option).repeat(1) }
+    klass.rule(:options?) { options.repeat(0, 1) }
+
+    klass.rule(:open)       { str('[') >> block_tag.as(:open) >> options?.as(:options) >> str(']') >> newline? }
+    klass.rule(:close)      { str('[/') >> block_tag.as(:close) >> str(']') >> newline? }
+    klass.rule(:open_close) { str('[') >> self_closing_tag.as(:open_close) >> options?.as(:options) >> str(']') >> newline? }
+
+    klass.rule(:text)   { ((close | block | open_close).absent? >> any).repeat(1).as(:text) }
+    klass.rule(:block)  { (open >> (block | text | open_close).repeat.as(:inner) >> close) }
+
+    klass.rule(:body) { (block | text | open_close).repeat.as(:body) }
+    klass.root(:body)
+  end
+
+  def define_match_any_of
+    klass.send(:define_method, :match_any_of) do |tags|
+      if tags.length < 1
+        return str('')
+      else
+        tags.map{ |tag| str(tag) }.inject do |tag_chain, tag|
+          tag_chain.send :|, tag
+        end
       end
     end
-
+  end
 end

--- a/lib/shortcode/presenter.rb
+++ b/lib/shortcode/presenter.rb
@@ -1,27 +1,19 @@
 class Shortcode::Presenter
+  def self.register(configuration, presenter)
+    validate presenter
+    [*presenter.for].each { |k| configuration.presenters[k.to_sym] = presenter }
+  end
 
-  class << self
-    attr_writer :presenters
-
-    def presenters
-      @presenters ||= {}
-    end
-
-    def register(presenter)
-      validate presenter
-      [*presenter.for].each { |k| presenters[k.to_sym] = presenter }
-    end
-
-    def validate(presenter)
-      raise ArgumentError, "The presenter must define the class method #for" unless presenter.respond_to?(:for)
-      raise ArgumentError, "The presenter must define an initialize method" unless presenter.private_instance_methods(false).include?(:initialize)
-      %w(content attributes).each do |method|
-        raise ArgumentError, "The presenter must define the method ##{method}" unless presenter.method_defined?(method.to_sym)
-      end
+  def self.validate(presenter)
+    raise ArgumentError, "The presenter must define the class method #for" unless presenter.respond_to?(:for)
+    raise ArgumentError, "The presenter must define an initialize method" unless presenter.private_instance_methods(false).include?(:initialize)
+    %w(content attributes).each do |method|
+      raise ArgumentError, "The presenter must define the method ##{method}" unless presenter.method_defined?(method.to_sym)
     end
   end
 
-  def initialize(name, attributes, content, additional_attributes)
+  def initialize(name, configuration, attributes, content, additional_attributes)
+    @configuration = configuration
     @attributes = attributes
     @content = content
     @additional_attributes = additional_attributes
@@ -38,12 +30,13 @@ class Shortcode::Presenter
 
   private
 
-    def initialize_custom_presenter(name)
-      if Shortcode::Presenter.presenters.has_key? name.to_sym
-        presenter   = Shortcode::Presenter.presenters[name.to_sym].new(@attributes, @content, @additional_attributes)
-        @attributes = presenter.attributes
-        @content    = presenter.content
-      end
-    end
+  attr_reader :configuration
 
+  def initialize_custom_presenter(name)
+    if configuration.presenters.has_key? name.to_sym
+      presenter   = configuration.presenters[name.to_sym].new(@attributes, @content, @additional_attributes)
+      @attributes = presenter.attributes
+      @content    = presenter.content
+    end
+  end
 end

--- a/lib/shortcode/processor.rb
+++ b/lib/shortcode/processor.rb
@@ -1,17 +1,16 @@
 class Shortcode::Processor
 
-  def process(string, additional_attributes=nil)
-    transformer.apply parser.parse(string), additional_attributes: additional_attributes
+  def process(string, configuration, additional_attributes=nil)
+    transformer(configuration).apply parser(configuration).parse(string), additional_attributes: additional_attributes
   end
 
   private
 
-    def parser
-      @parser ||= Shortcode::Parser.new
-    end
+  def parser(configuration)
+    @parser ||= Shortcode::Parser.new(configuration)
+  end
 
-    def transformer
-      @transformer ||= Shortcode::Transformer.new
-    end
-
+  def transformer(configuration)
+    @transformer ||= Shortcode::Transformer.new(configuration)
+  end
 end

--- a/lib/shortcode/tag.rb
+++ b/lib/shortcode/tag.rb
@@ -1,12 +1,13 @@
 class Shortcode::Tag
 
-  def initialize(name, attributes=[], content='', additional_attributes=nil)
+  def initialize(name, configuration, attributes=[], content='', additional_attributes=nil)
     @name = name.downcase
-    @binding = Shortcode::TemplateBinding.new(@name, attributes, content, additional_attributes)
+    @configuration = configuration
+    @binding = Shortcode::TemplateBinding.new(@name, @configuration, attributes, content, additional_attributes)
   end
 
   def markup
-    return markup_from_config unless Shortcode.configuration.templates.nil?
+    return markup_from_config unless configuration.templates.nil?
     template_files.each do |path|
       return File.read(path) if File.file? path
     end
@@ -19,34 +20,36 @@ class Shortcode::Tag
 
   private
 
-    def render_template
-      case Shortcode.configuration.template_parser
-      when :erb
-        ERB.new(markup).result(@binding.get_binding)
-      when :haml
-        Haml::Engine.new(markup).render(@binding)
-      when :slim
-        Slim::Template.new { markup }.render(@binding)
-      else
-        raise Shortcode::TemplateParserNotSupported, Shortcode.configuration.template_parser
-      end
-    end
+  attr_reader :configuration
 
-    def markup_from_config
-      if Shortcode.configuration.templates.has_key? @name.to_sym
-        Shortcode.configuration.templates[@name.to_sym]
-      else
-        raise Shortcode::TemplateNotFound, "Shortcode.configuration.templates does not contain the key #{@name.to_sym}"
-      end
+  def render_template
+    case configuration.template_parser
+    when :erb
+      ERB.new(markup).result(@binding.get_binding)
+    when :haml
+      Haml::Engine.new(markup).render(@binding)
+    when :slim
+      Slim::Template.new { markup }.render(@binding)
+    else
+      raise Shortcode::TemplateParserNotSupported, configuration.template_parser
     end
+  end
 
-    def template_files
-      template_paths.map do |filename|
-        File.join Shortcode.configuration.template_path, filename
-      end
+  def markup_from_config
+    if configuration.templates.has_key? @name.to_sym
+      configuration.templates[@name.to_sym]
+    else
+      raise Shortcode::TemplateNotFound, "configuration.templates does not contain the key #{@name.to_sym}"
     end
+  end
 
-    def template_paths
-      [ "#{@name}.html.#{Shortcode.configuration.template_parser.to_s}", "#{@name}.#{Shortcode.configuration.template_parser.to_s}" ]
+  def template_files
+    template_paths.map do |filename|
+      File.join configuration.template_path, filename
     end
+  end
+
+  def template_paths
+    [ "#{@name}.html.#{configuration.template_parser.to_s}", "#{@name}.#{configuration.template_parser.to_s}" ]
+  end
 end

--- a/lib/shortcode/template_binding.rb
+++ b/lib/shortcode/template_binding.rb
@@ -1,11 +1,12 @@
 class Shortcode::TemplateBinding
 
-  def initialize(name, attributes=[], content='', additional_attributes=nil)
+  def initialize(name, configuration, attributes=[], content='', additional_attributes=nil)
+    @configuration = configuration
     include_helper_modules
-    presenter   = Shortcode::Presenter.new name, set_attributes(attributes), content, additional_attributes
-    @name       = name
-    @attributes = presenter.attributes
-    @content    = presenter.content
+    presenter      = Shortcode::Presenter.new name, configuration, set_attributes(attributes), content, additional_attributes
+    @name          = name
+    @attributes    = presenter.attributes
+    @content       = presenter.content
   end
 
   # Expose private binding() method for use with erb templates
@@ -15,19 +16,20 @@ class Shortcode::TemplateBinding
 
   private
 
-    def set_attributes(attributes)
-      hash = {}
-      attributes.each { |o| hash[o[:key].to_sym] = o[:value] }
-      hash
-    end
+  attr_reader :configuration
 
-    def include_helper_modules
-      return unless Shortcode.configuration.helpers.any?
-      class << self
-        Shortcode.configuration.helpers.each do |helper|
-          include helper
-        end
+  def set_attributes(attributes)
+    hash = {}
+    attributes.each { |o| hash[o[:key].to_sym] = o[:value] }
+    hash
+  end
+
+  def include_helper_modules
+    return unless configuration.helpers.any?
+    class << self
+      configuration.helpers.each do |helper|
+        include helper
       end
     end
-
+  end
 end

--- a/lib/shortcode/template_binding.rb
+++ b/lib/shortcode/template_binding.rb
@@ -28,7 +28,7 @@ class Shortcode::TemplateBinding
     return unless configuration.helpers.any?
 
     configuration.helpers.each do |helper|
-      self.class.include(helper)
+      self.class.send(:include, helper)
     end
   end
 end

--- a/lib/shortcode/template_binding.rb
+++ b/lib/shortcode/template_binding.rb
@@ -26,10 +26,9 @@ class Shortcode::TemplateBinding
 
   def include_helper_modules
     return unless configuration.helpers.any?
-    class << self
-      configuration.helpers.each do |helper|
-        include helper
-      end
+
+    configuration.helpers.each do |helper|
+      self.class.include(helper)
     end
   end
 end

--- a/lib/shortcode/transformer.rb
+++ b/lib/shortcode/transformer.rb
@@ -1,17 +1,38 @@
-class Shortcode::Transformer < Parslet::Transform
+class Shortcode::Transformer
+  def initialize(configuration)
+    @configuration = configuration
+    setup_rules
+  end
 
-  rule(text: simple(:text)) { String(text) }
-  rule(
-    open:     simple(:name),
-    options:  subtree(:options),
-    inner:    sequence(:inner),
-    close:    simple(:name)
-  ) { Shortcode::Tag.new(name.to_s, options, inner.join, additional_attributes).render }
-  rule(
-    open_close: simple(:name),
-    options:    subtree(:options)
-  ) { Shortcode::Tag.new(name.to_s, options, '', additional_attributes).render }
+  def apply(str, options = {})
+    klass_instance.apply(str, options)
+  end
 
-  rule(body: sequence(:strings)) { strings.join }
+  private
 
+  def klass
+    @klass ||= Class.new(Parslet::Transform)
+  end
+
+  def klass_instance
+    @klass_instance ||= klass.new
+  end
+
+  def setup_rules
+    shortcode_configuration = @configuration
+
+    klass.rule(text: klass.send(:simple, :text)) { String(text) }
+    klass.rule(
+      open:     klass.send(:simple, :name),
+      options:  klass.send(:subtree, :options),
+      inner:    klass.send(:sequence, :inner),
+      close:    klass.send(:simple, :name)
+    ) { Shortcode::Tag.new(name.to_s, shortcode_configuration, options, inner.join, additional_attributes).render }
+    klass.rule(
+      open_close: klass.send(:simple, :name),
+      options:    klass.send(:subtree, :options)
+    ) { Shortcode::Tag.new(name.to_s, shortcode_configuration, options, '', additional_attributes).render }
+
+    klass.rule(body: klass.send(:sequence, :strings)) { strings.join }
+  end
 end

--- a/lib/shortcode/version.rb
+++ b/lib/shortcode/version.rb
@@ -1,3 +1,3 @@
-module Shortcode
+class Shortcode
   VERSION = "1.1.1"
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -3,8 +3,8 @@ require 'parslet/rig/rspec'
 require 'pp'
 
 describe Shortcode::Parser do
-
-  let(:parser) { Shortcode::Parser.new }
+  configuration = Shortcode.singleton.send(:configuration)
+  let(:parser) { Shortcode::Parser.new(configuration) }
 
   let(:simple_quote)      { load_fixture :simple_quote }
   let(:full_quote)        { load_fixture :full_quote }

--- a/spec/presenter_spec.rb
+++ b/spec/presenter_spec.rb
@@ -12,6 +12,7 @@ require 'support/presenters/missing_attributes_presenter'
 
 describe Shortcode::Presenter do
 
+  let(:configuration) { Shortcode.singleton.send(:configuration) }
   let(:simple_quote)  { load_fixture :simple_quote }
   let(:item)          { load_fixture :item }
 
@@ -35,7 +36,6 @@ describe Shortcode::Presenter do
   end
 
   describe "using a single presenter for multiple shortcodes" do
-
     let(:quote_presenter_output)  { load_fixture :simple_quote_presenter_output, :html }
     let(:item_presenter_output)   { load_fixture :item_presenter_output,         :html }
 
@@ -67,7 +67,7 @@ describe Shortcode::Presenter do
       end
 
       it "adds the presenter to the list" do
-        expect(Shortcode::Presenter.presenters).to include(MyPresenter.for)
+        expect(configuration.presenters).to include(MyPresenter.for)
       end
 
     end
@@ -79,8 +79,8 @@ describe Shortcode::Presenter do
       end
 
       it "adds the presenter to the list" do
-        expect(Shortcode::Presenter.presenters).to include(MyPresenter.for)
-        expect(Shortcode::Presenter.presenters).to include(OtherPresenter.for)
+        expect(configuration.presenters).to include(MyPresenter.for)
+        expect(configuration.presenters).to include(OtherPresenter.for)
       end
 
     end

--- a/spec/shortcode_spec.rb
+++ b/spec/shortcode_spec.rb
@@ -54,4 +54,29 @@ describe Shortcode do
 
   end
 
+  context "multiple instances" do
+    let(:shortcode1) { Shortcode.new }
+    let(:shortcode2) { Shortcode.new }
+
+    it "allows having multiple Shortcode instances that have independent configurations" do
+      expect(shortcode1.send(:configuration)).to_not be(shortcode2.send(:configuration))
+    end
+
+    it "uses the shortcode instance's configuration to process shortcodes" do
+      shortcode1.setup do |config|
+        config.self_closing_tags << :quote
+        config.templates = { quote: 'i am from shortcode 1' }
+      end
+
+      shortcode2.setup do |config|
+        config.self_closing_tags << :quote
+        config.templates = { quote: 'i am from shortcode 2' }
+      end
+
+      expect(shortcode1.process('[quote]')).to eq('i am from shortcode 1')
+      expect(shortcode2.process('[quote]')).to eq('i am from shortcode 2')
+    end
+
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,9 +16,9 @@ Slim::Engine.set_options attr_quote: "'"
 
 RSpec.configure do |config|
   config.order = "random"
+  config.color = true
 
   config.before(:each) do
-    Shortcode::Presenter.presenters = {}
     Shortcode.setup do |config|
       config.template_parser = :erb
       config.template_path = File.join File.dirname(__FILE__), "support/templates/erb"
@@ -27,6 +27,7 @@ RSpec.configure do |config|
       config.self_closing_tags = [:timeline_event, :timeline_info]
       config.attribute_quote_type = '"'
       config.use_attribute_quotes = true
+      config.presenters = {}
     end
   end
 end

--- a/spec/tag_spec.rb
+++ b/spec/tag_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 
 describe Shortcode::Tag do
+  let(:configuration) { Shortcode.singleton.send(:configuration) }
 
   context "when the template file is missing" do
 
-    let(:tag) { Shortcode::Tag.new('doesnt_exist') }
+    let(:tag) { Shortcode::Tag.new('doesnt_exist', configuration) }
 
     it "raises a TemplateNotFound error when the file doesn't exists" do
       expect { tag.render }.to raise_error(Shortcode::TemplateNotFound)
@@ -14,7 +15,7 @@ describe Shortcode::Tag do
 
   context "when an unsupported template parser is specified" do
 
-    let(:tag) { Shortcode::Tag.new('quote') }
+    let(:tag) { Shortcode::Tag.new('quote', configuration) }
 
     before(:each) do
       Shortcode.setup do |config|
@@ -30,7 +31,7 @@ describe Shortcode::Tag do
 
   context "templates from strings" do
 
-    let(:tag) { Shortcode::Tag.new('from_string', [{ key: 'string', value: 'batman' }]) }
+    let(:tag) { Shortcode::Tag.new('from_string', configuration, [{ key: 'string', value: 'batman' }]) }
 
     before(:each) do
       Shortcode.setup do |config|
@@ -48,7 +49,7 @@ describe Shortcode::Tag do
 
   context "when the template is missing from the config" do
 
-    let(:tag) { Shortcode::Tag.new('missing', [{ key: 'string', value: 'batman' }]) }
+    let(:tag) { Shortcode::Tag.new('missing', configuration, [{ key: 'string', value: 'batman' }]) }
 
     before(:each) do
       Shortcode.setup do |config|

--- a/spec/template_parsers_spec.rb
+++ b/spec/template_parsers_spec.rb
@@ -23,7 +23,7 @@ describe "template parsers" do
     end
 
     it "can render a template" do
-      expect(Shortcode.process(simple_quote).gsub("\n",'')).to eq(simple_quote_output)
+      expect(Shortcode.process(simple_quote).gsub("\n",'').gsub('>  <', '><')).to eq(simple_quote_output)
     end
 
   end

--- a/spec/transformer_spec.rb
+++ b/spec/transformer_spec.rb
@@ -3,9 +3,9 @@ require 'parslet/rig/rspec'
 require 'pp'
 
 describe Shortcode do
-
-  let(:parser)      { Shortcode::Parser.new }
-  let(:transformer) { Shortcode::Transformer.new }
+  configuration = Shortcode.singleton.send(:configuration)
+  let(:parser)      { Shortcode::Parser.new(configuration) }
+  let(:transformer) { Shortcode::Transformer.new(configuration) }
 
   let(:simple_quote)          { load_fixture :simple_quote }
   let(:full_quote)            { load_fixture :full_quote }


### PR DESCRIPTION
This is an alternative implementation of multiple `Shortcode` instances.

I converted the `Shortcode` module to a class, but it should be backwards compatible because I have the class methods use a default instance of the `Shortcode` class when methods are called on `Shortcode` directly.

I plan on doing some more work on this to clean it up and flesh out some of the specs.  This is just my first go at it.

I am currently using the shortcode gem in production for my work.  It is used on Raise.me, however because multiple instances with independent configurations aren't yet supported, in our app we had to create a wrapper class that swaps out the configuration and presenters before calling `Shortcode.process` on a string.

If this gets merged in (after some more changes I suspect) then I'll be able to rewrite that part of our app and depend more on the `Shortcode` gem and less on our hacky workaround.