### PR TITLE
Template from configuration or file

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,7 @@ shortcode.setup do |config|
 end
 ```
 
-If the `templates` config option is set all templates will be loaded from this hash, if a shortcode is encountered without a matching key in the `templates` config option
-an exception will be raised.
-
-Note: it's NOT possible to load templates from a config option AND from the file system, you must either load all templates from the file system or define all templates in a config option.
+Note: Templates can be loaded from either the file system or the configuration templates.  If `check_config_templates_first` is set to true (the default value) on the configuration then it will check configuration templates first, and file system templates if it doesn't find one.  If `check_config_templates_first` is set to false on the configuration it will check for a file system template first, and then configuration templates if it doesn't find one.  If it doesn't find a template in either spot then it will raise an error.
 
 ### Custom Helpers
 
@@ -257,9 +254,11 @@ shortcode.setup do |config|
   # location of the template files, default is "app/views/shortcode_templates"
   config.template_path = "support/templates/erb"
 
-  # a hash of templates passed as strings, if this is set it overrides the
-  # above template_path option. The default is nil
+  # a hash of templates passed as strings.
   config.templates = { gallery: 'template code' }
+
+  # a boolean option to set whether configuration templates are checked first or file system templates
+  config.check_config_templates_first = true
 
   # an array of helper modules to make available within templates
   config.helpers = [CustomerHelper]

--- a/lib/shortcode/configuration.rb
+++ b/lib/shortcode/configuration.rb
@@ -8,6 +8,9 @@ class Shortcode::Configuration
   # Allows templates to be set from strings rather than read from the filesystem
   attr_accessor :templates
 
+  # Allows setting whether templates on the configuration are checked first, or templates in the file system
+  attr_accessor :check_config_templates_first
+
   # Assigns helper modules to be included in templates
   attr_accessor :helpers
 
@@ -33,15 +36,16 @@ class Shortcode::Configuration
   attr_accessor :use_attribute_quotes
 
   def initialize
-    @template_parser      = :erb
-    @template_path        = "app/views/shortcode_templates"
-    @templates            = nil
-    @helpers              = []
-    @block_tags           = []
-    @self_closing_tags    = []
-    @attribute_quote_type = '"'
-    @use_attribute_quotes = true
-    @presenters           = {}
+    @template_parser              = :erb
+    @template_path                = "app/views/shortcode_templates"
+    @templates                    = {}
+    @check_config_templates_first = true
+    @helpers                      = []
+    @block_tags                   = []
+    @self_closing_tags            = []
+    @attribute_quote_type         = '"'
+    @use_attribute_quotes         = true
+    @presenters                   = {}
   end
 
   def register_presenter(presenter)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,8 @@ RSpec.configure do |config|
     Shortcode.setup do |config|
       config.template_parser = :erb
       config.template_path = File.join File.dirname(__FILE__), "support/templates/erb"
+      config.templates = {}
+      config.check_config_templates_first = true
       config.block_tags = [:quote, :collapsible_list, :item, :timeline_person, :rails_helper, :custom_helper]
       config.self_closing_tags = [:timeline_event, :timeline_info]
       config.attribute_quote_type = '"'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,6 @@ RSpec.configure do |config|
     Shortcode.setup do |config|
       config.template_parser = :erb
       config.template_path = File.join File.dirname(__FILE__), "support/templates/erb"
-      config.templates = nil
       config.block_tags = [:quote, :collapsible_list, :item, :timeline_person, :rails_helper, :custom_helper]
       config.self_closing_tags = [:timeline_event, :timeline_info]
       config.attribute_quote_type = '"'

--- a/spec/tag_spec.rb
+++ b/spec/tag_spec.rb
@@ -65,4 +65,22 @@ describe Shortcode::Tag do
 
   end
 
+  context "when templates exist both in configuration and file system" do
+    let(:tag) { Shortcode::Tag.new('quote', configuration ) }
+
+    before(:each) do
+      configuration.templates[:quote] = '<p><%= @content %></p>'
+    end
+
+    it 'uses the configuration template when check_config_templates_first is true' do
+      expect(tag.markup).to eq('<p><%= @content %></p>')
+    end
+
+    it 'uses the file system template when check_config_templates_first is false' do
+      configuration.check_config_templates_first = false
+
+      expect(tag.markup).to eq(File.open('spec/support/templates/erb/quote.html.erb').read)
+    end
+  end
+
 end

--- a/spec/tag_spec.rb
+++ b/spec/tag_spec.rb
@@ -66,16 +66,15 @@ describe Shortcode::Tag do
   end
 
   context "when templates exist both in configuration and file system" do
-    before(:each) do
-      configuration.templates[:quote] = '<p><%= @content %></p>'
-    end
-
     it 'uses the configuration template when check_config_templates_first is true' do
+      configuration.templates[:quote] = '<p><%= @content %></p>'
+      configuration.check_config_templates_first = true
       tag = Shortcode::Tag.new('quote', configuration )
       expect(tag.markup).to eq('<p><%= @content %></p>')
     end
 
     it 'uses the file system template when check_config_templates_first is false' do
+      configuration.templates[:quote] = '<p><%= @content %></p>'
       configuration.check_config_templates_first = false
       tag = Shortcode::Tag.new('quote', configuration )
 

--- a/spec/tag_spec.rb
+++ b/spec/tag_spec.rb
@@ -66,17 +66,18 @@ describe Shortcode::Tag do
   end
 
   context "when templates exist both in configuration and file system" do
-    it 'uses the configuration template when check_config_templates_first is true' do
+    let(:tag) { Shortcode::Tag.new('quote', configuration ) }
+
+    before(:each) do
       configuration.templates[:quote] = '<p><%= @content %></p>'
-      configuration.check_config_templates_first = true
-      tag = Shortcode::Tag.new('quote', configuration )
+    end
+
+    it 'uses the configuration template when check_config_templates_first is true' do
       expect(tag.markup).to eq('<p><%= @content %></p>')
     end
 
     it 'uses the file system template when check_config_templates_first is false' do
-      configuration.templates[:quote] = '<p><%= @content %></p>'
       configuration.check_config_templates_first = false
-      tag = Shortcode::Tag.new('quote', configuration )
 
       expect(tag.markup).to eq(File.open('spec/support/templates/erb/quote.html.erb').read)
     end

--- a/spec/tag_spec.rb
+++ b/spec/tag_spec.rb
@@ -66,18 +66,18 @@ describe Shortcode::Tag do
   end
 
   context "when templates exist both in configuration and file system" do
-    let(:tag) { Shortcode::Tag.new('quote', configuration ) }
-
     before(:each) do
       configuration.templates[:quote] = '<p><%= @content %></p>'
     end
 
     it 'uses the configuration template when check_config_templates_first is true' do
+      tag = Shortcode::Tag.new('quote', configuration )
       expect(tag.markup).to eq('<p><%= @content %></p>')
     end
 
     it 'uses the file system template when check_config_templates_first is false' do
       configuration.check_config_templates_first = false
+      tag = Shortcode::Tag.new('quote', configuration )
 
       expect(tag.markup).to eq(File.open('spec/support/templates/erb/quote.html.erb').read)
     end


### PR DESCRIPTION
This allows templates to be loaded from the configuration and the file system.  It adds the `check_config_templates_first` option to the configuration so you can set whether it checks the configuration templates or the file system templates first.

It will raise an error only if it can't find a template in either place.

I can rename the `check_config_templates_first` easily enough if we have a better name for it.  This will solve issue #47 and allow me to move forward with #46.

It doesn't directly block #46, but it would be annoying to do that first only to have to redo some of the logic because of this PR.