### PR TITLE
Do not call `.setup` on Singleton when loading the main lib

### DIFF
--- a/lib/shortcode.rb
+++ b/lib/shortcode.rb
@@ -65,4 +65,3 @@ require 'shortcode/tag'
 require 'shortcode/exceptions'
 require 'shortcode/railtie' if defined?(Rails) && Rails::VERSION::MAJOR >= 3
 
-Shortcode.setup {}


### PR DESCRIPTION
Hi @kernow,

First, thank you very much for this incredible library. It helped me a lot setting up configurable templates for my CMS 🎉

This PR aims to fix the following issue: after I installed Shortcode latest version, I kept reading on my logs the `[DEPRECATION] singleton Shortcode.setup` warning, which was not true in my case. I barely installed the gem, how I was calling the `Shortcode.setup` method? 🤔. I didn't know where this was coming, until I checked out the library code.

Based on latest master, I noticed that the `Shortcode.setup` delegates its call to the `.singleton` method, which initializes a new instance of the `Shortcode` object. This will trigger the library default configuration, calling `Shortcode.setup` or not.

This behavior also makes the `Shortcode.setup {}` call at the end of the `lib/shortcode.rb` file unnecessary (https://github.com/kernow/shortcode/blob/8f539c8110d25d50e331c57fa4dca24a274dd16c/lib/shortcode.rb#L68), removing the deprecation warning for users using the library latest version 😃 

Also tested it locally running `appraisal rspec`, and all tests are green 😄 