### PR TITLE
Allow presenters to define initialize via inheritance

### DIFF
--- a/lib/shortcode/presenter.rb
+++ b/lib/shortcode/presenter.rb
@@ -7,15 +7,19 @@ class Shortcode::Presenter
 
   def self.validate(presenter)
     raise ArgumentError, "The presenter must define the class method #for" unless presenter.respond_to?(:for)
-    unless presenter.private_instance_methods(false).include?(:initialize)
-      raise ArgumentError, "The presenter must define an initialize method"
-    end
+    raise ArgumentError, "The presenter must define an initialize method" unless init_defined?(presenter)
 
     %w[content attributes].each do |method|
       unless presenter.method_defined?(method.to_sym)
         raise ArgumentError, "The presenter must define the method ##{method}"
       end
     end
+  end
+
+  def self.init_defined?(presenter)
+    return false if presenter == Object
+
+    presenter.private_instance_methods(false).include?(:initialize) || init_defined?(presenter.superclass)
   end
 
   def initialize(name, configuration, attributes, content, additional_attributes)

--- a/spec/shortcode/presenter_spec.rb
+++ b/spec/shortcode/presenter_spec.rb
@@ -8,6 +8,7 @@ require "support/presenters/multiple_presenter"
 require "support/presenters/missing_for_presenter"
 require "support/presenters/missing_initialize_presenter"
 require "support/presenters/child_presenter"
+require "support/presenters/child_missing_initialize_presenter"
 require "support/presenters/missing_content_presenter"
 require "support/presenters/missing_attributes_presenter"
 
@@ -106,6 +107,13 @@ describe Shortcode::Presenter do
       it "does not raise an exception" do
         expect { shortcode.register_presenter ChildPresenter }
           .not_to raise_error
+      end
+    end
+
+    context "when self and ancestory are missing #initialize method" do
+      it "raises an exception" do
+        expect { shortcode.register_presenter ChildMissingInitializePresenter }
+          .to raise_error(ArgumentError, "The presenter must define an initialize method")
       end
     end
 

--- a/spec/shortcode/presenter_spec.rb
+++ b/spec/shortcode/presenter_spec.rb
@@ -7,6 +7,7 @@ require "support/presenters/other_presenter"
 require "support/presenters/multiple_presenter"
 require "support/presenters/missing_for_presenter"
 require "support/presenters/missing_initialize_presenter"
+require "support/presenters/child_presenter"
 require "support/presenters/missing_content_presenter"
 require "support/presenters/missing_attributes_presenter"
 
@@ -98,6 +99,13 @@ describe Shortcode::Presenter do
       it "raises an exception" do
         expect { shortcode.register_presenter MissingInitializePresenter }
           .to raise_error(ArgumentError, "The presenter must define an initialize method")
+      end
+    end
+
+    context "when initialize exists on non-Object ancestor class" do
+      it "does not raise an exception" do
+        expect { shortcode.register_presenter ChildPresenter }
+          .not_to raise_error
       end
     end
 

--- a/spec/support/presenters/child_missing_initialize_presenter.rb
+++ b/spec/support/presenters/child_missing_initialize_presenter.rb
@@ -1,0 +1,11 @@
+require "support/presenters/parent_missing_initialize_presenter"
+
+class ChildMissingInitializePresenter < ParentMissingInitializePresenter
+
+  def self.for; end
+
+  def content; end
+
+  def attributes; end
+
+end

--- a/spec/support/presenters/child_presenter.rb
+++ b/spec/support/presenters/child_presenter.rb
@@ -1,0 +1,11 @@
+require "support/presenters/parent_presenter"
+
+class ChildPresenter < ParentPresenter
+
+  def self.for; end
+
+  def content; end
+
+  def attributes; end
+
+end

--- a/spec/support/presenters/parent_missing_initialize_presenter.rb
+++ b/spec/support/presenters/parent_missing_initialize_presenter.rb
@@ -1,0 +1,2 @@
+class ParentMissingInitializePresenter
+end

--- a/spec/support/presenters/parent_presenter.rb
+++ b/spec/support/presenters/parent_presenter.rb
@@ -1,0 +1,5 @@
+class ParentPresenter
+
+  def initialize; end
+
+end


### PR DESCRIPTION
It would be nice to be able to define a BasePresenter that defines some
base helper methods or even defines a default behavior for the 4
required methods. Then it would be up to any child classes to override
that default behavior.

Currently this is possible for `self.for`, `content`, and `attributes`.
But initialize is weird because `Object` defines initialize and we don't
want that to "count".

So in order to support the initialize being inheritable to child
classes, I've changed the condition around when we throw the validation
error to check the presenter's class ancestory _until_ we reach Object.
At that point we assume failure and raise the validation error.