### PR TITLE
Remove executables from gemspec

### DIFF
--- a/shortcode.gemspec
+++ b/shortcode.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
This gem does not have any executables. Previous versions included the rubocop/rspec/appraisals binstubs. Fixes #58 

Tests before the PR:

```
shortcode$ bin/rspec
The `rspec` executable in the `rspec-core` gem is being loaded, but it's also present in other gems (shortcode).
If you meant to run the executable for another gem, make sure you use a project specific binstub (`bundle binstub <gem_name>`).
If you plan to use multiple conflicting executables, generate binstubs for them and disambiguate their names.

Randomized with seed 65244
...........................................................

Finished in 0.20697 seconds (files took 0.5488 seconds to load)
59 examples, 0 failures

Randomized with seed 65244
```

Tests after the PR:

```
$ bin/rspec

Randomized with seed 43142
...........................................................

Finished in 0.2537 seconds (files took 0.53934 seconds to load)
59 examples, 0 failures

Randomized with seed 43142
```